### PR TITLE
Remove module builder backend dependency

### DIFF
--- a/src/app/common/services/module.service.ts
+++ b/src/app/common/services/module.service.ts
@@ -70,10 +70,6 @@ export class ModuleService {
     );
   }
 
-  getTemplates(moduleId: number): Observable<Template[]> {
-    return this.httpClient.get<Template[]>(`${this.baseUrl}/${moduleId}/templates`);
-  }
-
   getTemplateResources(moduleId: number, template: string): Observable<string[]> {
     return this.httpClient.get<string[]>(`${this.baseUrl}/${moduleId}/templates/resources?template=` + template);
   }

--- a/src/app/module-builder/module-editor/step-template-editor/step-template-editor.component.html
+++ b/src/app/module-builder/module-editor/step-template-editor/step-template-editor.component.html
@@ -8,7 +8,6 @@
   <div class="form-group">
     <label>Template</label>
     <select
-      *ngIf="(templates$ | async) as templates"
       [ngModelOptions]="{standalone: true}"
       [(ngModel)]="stepEdit.template_component"
       (ngModelChange)="onTemplateChange($event)"

--- a/src/app/module-builder/module-editor/step-template-editor/step-template-editor.component.ts
+++ b/src/app/module-builder/module-editor/step-template-editor/step-template-editor.component.ts
@@ -30,7 +30,7 @@ export class StepTemplateEditorComponent implements OnInit {
       this.stepEdit.template_params_json = {};
     }
 
-    this.templates = Object.entries(Templates).map(([id, tplClass]) => {
+    this.templates = Object.keys(Templates).map(id => {
       const inst = new Templates[id]();
 
       return {

--- a/src/app/module-viewer/riverside-step-template/templates/age-gender/age-gender.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/age-gender/age-gender.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, forwardRef } from '@angular/core';
 import { PersonaInputs } from '../persona-ids.class';
 import { TemplateComponent } from '../template-base.class';
-import { AgeGenderTemplateData } from '.';
+import { TemplateParams, AgeGenderTemplateData } from '.';
 
 @Component({
   selector: 'app-age-gender',
@@ -10,6 +10,7 @@ import { AgeGenderTemplateData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => AgeGenderComponent) }]
 })
 export class AgeGenderComponent extends TemplateComponent implements OnInit {
+  params = TemplateParams;
   inputIds: PersonaInputs;
   contentData: AgeGenderTemplateData['template_params_json'];
   traits = [

--- a/src/app/module-viewer/riverside-step-template/templates/age-gender/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/age-gender/index.ts
@@ -7,3 +7,9 @@ export interface AgeGenderTemplateData extends TemplateContentDataBase {
     instructions?: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+  instructions?: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/brainstorm/brainstorm.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/brainstorm/brainstorm.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { BrainstormTemplateData } from '.';
+import { BrainstormTemplateData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-brainstorm',
@@ -10,6 +10,7 @@ import { BrainstormTemplateData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => BrainstormTemplateComponent) }]
 })
 export class BrainstormTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds = ['brainstorm'];
 
   contentData: BrainstormTemplateData['template_params_json'];

--- a/src/app/module-viewer/riverside-step-template/templates/brainstorm/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/brainstorm/index.ts
@@ -6,3 +6,8 @@ export interface BrainstormTemplateData extends TemplateContentDataBase {
     title: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/feedback_section/feedback_section.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/feedback_section/feedback_section.component.ts
@@ -2,6 +2,7 @@ import { Component, forwardRef } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
 import { data } from './exampleData';
 import { PersonaInputs } from '../persona-ids.class';
+import { TemplateParams } from '.';
 
 @Component({
   selector: 'app-feedback_section',
@@ -10,6 +11,7 @@ import { PersonaInputs } from '../persona-ids.class';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => FeedbackSectionTemplateComponent) }]
 })
 export class FeedbackSectionTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds: PersonaInputs;
 
   contentData = data;

--- a/src/app/module-viewer/riverside-step-template/templates/feedback_section/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/feedback_section/index.ts
@@ -11,3 +11,13 @@ export interface FeedbackSectionTemplateData extends TemplateContentDataBase {
     }>
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+  instructions: string;
+  steps: Array<{
+    sufix: string,
+    title: string;
+  }>
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/final-feedback/final-feedback.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/final-feedback/final-feedback.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, forwardRef } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
 import { data } from './exampleData';
 import { FeedbackSectionTemplateComponent } from '../feedback_section/feedback_section.component';
+import { TemplateParams } from '.';
 
 @Component({
   selector: 'app-final-feedback',
@@ -10,6 +11,7 @@ import { FeedbackSectionTemplateComponent } from '../feedback_section/feedback_s
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => FinalFeedbackComponent) }]
 })
 export class FinalFeedbackComponent extends FeedbackSectionTemplateComponent implements OnInit  {
+  params = TemplateParams;
   contentData = data;
 
   columnBoxes = [

--- a/src/app/module-viewer/riverside-step-template/templates/final-feedback/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/final-feedback/index.ts
@@ -11,3 +11,13 @@ export interface FinalFeedbackTemplateData extends TemplateContentDataBase {
     }>
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+  instructions: string;
+  steps: Array<{
+    sufix: string,
+    title: string;
+  }>
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/generic/generic.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/generic/generic.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { GenericTemplateData } from '.';
+import { GenericTemplateData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-generic',
@@ -10,6 +10,7 @@ import { GenericTemplateData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => GenericTemplateComponent) }]
 })
 export class GenericTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   contentData: GenericTemplateData['template_params_json'];
 
   protected init() {

--- a/src/app/module-viewer/riverside-step-template/templates/generic/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/generic/index.ts
@@ -7,3 +7,9 @@ export interface GenericTemplateData extends TemplateContentDataBase {
     title: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  content: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/name_personas/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/name_personas/index.ts
@@ -7,3 +7,9 @@ export interface NamePersonasTemplateData extends TemplateContentDataBase {
     title: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  resource: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/name_personas/name_personas.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/name_personas/name_personas.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { NamePersonasTemplateData } from '.';
+import { NamePersonasTemplateData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-name_personas',
@@ -10,6 +10,7 @@ import { NamePersonasTemplateData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => NamePersonasTemplateComponent) }]
 })
 export class NamePersonasTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds: {
     personas: string[]
   };

--- a/src/app/module-viewer/riverside-step-template/templates/narrow-down/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/narrow-down/index.ts
@@ -6,3 +6,8 @@ export interface NarrowDownData extends TemplateContentDataBase {
     title: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/narrow-down/narrow-down.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/narrow-down/narrow-down.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { NarrowDownData } from '.';
+import { NarrowDownData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-template2',
@@ -10,6 +10,7 @@ import { NarrowDownData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => NarrowDownComponent) }]
 })
 export class NarrowDownComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds = {
     fromPreviousStep: ['brainstorm_personas'],
     personas: [

--- a/src/app/module-viewer/riverside-step-template/templates/persona-picture/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/persona-picture/index.ts
@@ -6,3 +6,8 @@ export interface PersonaPictureTemplateData extends TemplateContentDataBase {
     title: string;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/persona-picture/persona-picture.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/persona-picture/persona-picture.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { PersonaPictureTemplateData } from '.';
+import { PersonaPictureTemplateData, TemplateParams } from '.';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { PersonaPictureListComponent } from './persona-picture-list/persona-picture-list.component';
 
@@ -14,6 +14,7 @@ import { PersonaPictureListComponent } from './persona-picture-list/persona-pict
 })
 
 export class PersonaPictureTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds = {
     fromPreviousStep: [ ],
     personas: [ ]

--- a/src/app/module-viewer/riverside-step-template/templates/persona_behavior/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/persona_behavior/index.ts
@@ -16,3 +16,18 @@ export interface PersonaBehaviorTemplateData extends TemplateContentDataBase {
     }>
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  resource: string;
+  example: string;
+  instructions: string;
+  title: string;
+  input_sufix: string;
+  behavior: string;
+  formatAsList: boolean;
+  selection_matrix: Array<{
+    question: string,
+    options: Array<{option: string}>
+  }>
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/persona_behavior/persona_behavior.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/persona_behavior/persona_behavior.component.ts
@@ -1,7 +1,7 @@
 import { Component, forwardRef } from '@angular/core';
 
 import { TemplateComponent } from '../template-base.class';
-import { PersonaBehaviorTemplateData } from '.';
+import { PersonaBehaviorTemplateData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-persona_behavior',
@@ -12,6 +12,7 @@ import { PersonaBehaviorTemplateData } from '.';
 })
 
 export class PersonaBehaviorTemplateComponent extends TemplateComponent {
+  params = TemplateParams;
   inputIds: {
     personas: string[]
   };

--- a/src/app/module-viewer/riverside-step-template/templates/question-image/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/question-image/index.ts
@@ -15,3 +15,11 @@ export interface SegmentCriteria {
   description: {content: string, comments_json: string};
   weight?: number;
 }
+
+export const TemplateParams = `{
+  description: string;
+  instructions: string;
+  image: string;
+  title: string;
+  questions: Array<{question: string}>
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/question-image/question-image.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/question-image/question-image.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChild, forwardRef, ElementRef } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
-import { QuestionImageTemplateData } from '.';
+import { QuestionImageTemplateData, TemplateParams } from '.';
 import { DomSanitizer, SafeStyle, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
@@ -11,7 +11,7 @@ import { DomSanitizer, SafeStyle, SafeResourceUrl } from '@angular/platform-brow
   preserveWhitespaces: true
 })
 export class QuestionImageComponent extends TemplateComponent {
-
+  params = TemplateParams;
   contentData: QuestionImageTemplateData['template_params_json'];
 
   pdf: SafeResourceUrl;

--- a/src/app/module-viewer/riverside-step-template/templates/segment-criteria-define/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/segment-criteria-define/index.ts
@@ -20,3 +20,14 @@ export interface SegmentCriteria {
   description: {content: string, comments_json: string};
   weight?: number;
 }
+
+export const TemplateParams = `{
+  step_select: '1_define_segments' | '2_brainstorm_criteria' | '3_define_criteria' |
+               '4_assign_weight' | '5_request_feedback_section_1' | '6_decide_letter_grades' |
+               '7_grade_customers' | '8_request_feedback_section_2';
+  description: string;
+  instructions?: string;
+  number_of_inputs: number;
+  inputs: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/segment-criteria-define/segment-criteria-define.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/segment-criteria-define/segment-criteria-define.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, forwardRef, QueryList, ViewChildren } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
-import { SegmentCriteria, SegmentCriteriaDefineTemplateData } from '.';
+import { SegmentCriteria, SegmentCriteriaDefineTemplateData, TemplateParams } from '.';
 import { IcpInputComponent } from './icp-input/icp-input.component';
 import { Validate } from 'src/app/common/validator.class';
 
@@ -15,6 +15,8 @@ const inputs = ['on', 'name', 'industries', 'pain_points', 'brainstorm', 'whe
 export class SegmentCriteriaDefineComponent extends TemplateComponent implements OnInit {
 
   @ViewChildren(IcpInputComponent) icpInputs: QueryList<IcpInputComponent>;
+
+  params = TemplateParams;
 
   contentData: SegmentCriteriaDefineTemplateData['template_params_json'];
 

--- a/src/app/module-viewer/riverside-step-template/templates/spreadsheet/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/spreadsheet/index.ts
@@ -10,3 +10,12 @@ export interface SpreadsheetTemplateData extends TemplateContentDataBase {
     calculateFormulasOnServer: boolean;
   };
 }
+
+export const TemplateParams = `{
+  description: string;
+  apiResource: string;
+  visibleRows: string;
+  title: string;
+  requireFeedback: boolean;
+  calculateFormulasOnServer: boolean;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/spreadsheet/spreadsheet.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/spreadsheet/spreadsheet.component.ts
@@ -1,6 +1,6 @@
 import { Component, forwardRef, ViewChild, ElementRef } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
-import { SpreadsheetTemplateData } from '.';
+import { SpreadsheetTemplateData, TemplateParams } from '.';
 import * as Handsontable from 'handsontable';
 import { Subscription } from 'rxjs';
 import { SpreadsheetResource, TemplateInput } from 'src/app/common/interfaces/module.interface';
@@ -48,6 +48,8 @@ class PercentageEditor extends Handsontable.editors.TextEditor {
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => SpreadsheetComponent) }]
 })
 export class SpreadsheetComponent extends TemplateComponent {
+
+  params = TemplateParams;
 
   private spreadsheetService: SpreadsheetService;
   private hotRegister = new HotTableRegisterer();

--- a/src/app/module-viewer/riverside-step-template/templates/template-base.class.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/template-base.class.ts
@@ -14,6 +14,7 @@ import { Validation, Validate } from 'src/app/common/validator.class';
 @Component({})
 export abstract class TemplateComponent implements TemplateComponentInterface, OnInit, OnDestroy {
 
+  protected abstract params: string;
   abstract contentData;
 
   data: TemplateContentData;
@@ -158,5 +159,9 @@ export abstract class TemplateComponent implements TemplateComponentInterface, O
     if (input.error) {
       input.error.next(null);
     }
+  }
+
+  getBuilderParams() {
+    return this.params;
   }
 }

--- a/src/app/module-viewer/riverside-step-template/templates/video/index.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/video/index.ts
@@ -9,3 +9,9 @@ export interface VideoTemplateData extends TemplateContentDataBase {
   };
 }
 
+export const TemplateParams = `{
+  description: string;
+  videoUrl: string;
+  content: string;
+  title: string;
+}`;

--- a/src/app/module-viewer/riverside-step-template/templates/video/video.component.ts
+++ b/src/app/module-viewer/riverside-step-template/templates/video/video.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, forwardRef } from '@angular/core';
 import { TemplateComponent } from '../template-base.class';
-import { VideoTemplateData } from '.';
+import { VideoTemplateData, TemplateParams } from '.';
 
 @Component({
   selector: 'app-video',
@@ -9,6 +9,7 @@ import { VideoTemplateData } from '.';
   providers: [{ provide: TemplateComponent, useExisting: forwardRef(() => VideoComponent) }]
 })
 export class VideoComponent extends TemplateComponent implements OnInit {
+  params = TemplateParams;
   contentData: VideoTemplateData['template_params_json'];
 
   videoProvider: 'Vimeo' | 'Youtube';


### PR DESCRIPTION
Duplicate template param type definitions as string to be able to read them locally without parsing TypeScript files via backend.